### PR TITLE
Making some information from the jar metadata accessible externally.

### DIFF
--- a/src/main/java/net/minecraftforge/lex/mappingtoy/JarMetadata.java
+++ b/src/main/java/net/minecraftforge/lex/mappingtoy/JarMetadata.java
@@ -397,7 +397,7 @@ public class JarMetadata {
         }
     }
 
-    private static interface IAccessible {
+    public static interface IAccessible {
         int getAccess();
 
         default boolean isInterface() {
@@ -499,6 +499,30 @@ public class JarMetadata {
             return this.superName == null && !"java/lang/Object".equals(this.name) ? "java/lang/Object" : this.superName;
         }
 
+        public String getName() {
+            return name;
+        }
+
+        public List<String> getInterfaces() {
+            return this.interfaces == null ? Collections.emptyList() : this.interfaces;
+        }
+
+        public String getSignature() {
+            return this.signature == null ? "" : this.signature;
+        }
+
+        public Map<String, FieldInfo> getFields() {
+            return this.fields == null ? Collections.emptyMap() : this.fields;
+        }
+
+        public Map<String, MethodInfo> getMethods() {
+            return methods == null ? Collections.emptyMap() : this.methods;
+        }
+
+        public boolean isResolved() {
+            return resolved;
+        }
+
         @Override
         public int getAccess() {
             return access == null ? 0 : access;
@@ -535,6 +559,14 @@ public class JarMetadata {
             @Override
             public String toString() {
                 return Utils.getAccess(getAccess()) + ' ' + this.desc + ' ' + this.name;
+            }
+
+            public String getSignature() {
+                return this.signature == null ? "" : this.signature;
+            }
+
+            public String getForce() {
+                return this.force == null ? "" : this.force;
             }
         }
 
@@ -619,6 +651,14 @@ public class JarMetadata {
                 return this.overrides == null ? Collections.emptySet() : this.overrides;
             }
 
+            public String getSignature() {
+                return this.signature == null ? "" : this.signature;
+            }
+
+            public String getForce() {
+                return this.force == null ? "" : this.force;
+            }
+
             public String getOwner() {
                 return ClassInfo.this.name;
             }
@@ -627,6 +667,8 @@ public class JarMetadata {
             public String toString() {
                 return Utils.getAccess(getAccess()) + ' ' + this.name + ' ' + this.desc;
             }
+
+
         }
     }
 


### PR DESCRIPTION
This allows external systems, like ModMappings, to access MappingToy's metadata when they consume mapping toy as an external library.

This is needed so that the importer for ModMappings does not need to contain a copy of the classes, and just can delegate the handling of this logic and code to MappingToy.