### PR TITLE
Allow for etags that aren't generated using AmazonS3

### DIFF
--- a/src/main/java/net/minecraftforge/lex/mappingtoy/Utils.java
+++ b/src/main/java/net/minecraftforge/lex/mappingtoy/Utils.java
@@ -93,11 +93,11 @@ public class Utils {
                 copy(in, out);
             }
 
-            if (etag.indexOf('-') != -1) return true; //No-etag, don't store it
+            if (etag.equals("-")) return true; //No-etag, don't store it
 
             Files.write(etagFile, etag.getBytes());
-            
-            if (!connection.getHeaderField("server").equals("AmazonS3")) return true; // Etag is not from AmazonS3 which uses plain md5 hashes, assume valid
+
+            if (!"AmazonS3".equals(connection.getHeaderField("server")) || etag.contains("-")) return true; // Etag is not from AmazonS3 which uses plain md5 hashes or the file is a multipart upload in which case the etag is the md5 hash of all parts concatenated after being decoded from hex, assume valid
             String md5 = HashFunction.MD5.hash(file);
 
             if (!etag.equalsIgnoreCase(md5)) {

--- a/src/main/java/net/minecraftforge/lex/mappingtoy/Utils.java
+++ b/src/main/java/net/minecraftforge/lex/mappingtoy/Utils.java
@@ -70,16 +70,14 @@ public class Utils {
             connection.setReadTimeout(5000);
 
             Path etagFile = file.getParent().resolve(file.getFileName() + ".etag");
-            String foundEtag = Files.isRegularFile(etagFile) ? new String(readStreamFully(etagFile)) : "-";
-            if (!force && Files.isRegularFile(file))
+            if (!force && Files.isRegularFile(etagFile) && Files.isRegularFile(file)) {
+                String foundEtag = Files.isRegularFile(etagFile) ? new String(readStreamFully(etagFile)) : "-";
                 connection.setRequestProperty("If-None-Match", '"' + foundEtag + '"');
-
+            }
             connection.connect();
 
             String etag = connection.getHeaderField("ETag");
-            if (etag == null)
-                etag = "-";
-            else if ((etag.startsWith("\"")) && (etag.endsWith("\"")))
+            if (etag != null && (etag.startsWith("\"")) && (etag.endsWith("\"")))
                 etag = etag.substring(1, etag.length() - 1);
 
             int response = connection.getResponseCode();
@@ -93,7 +91,7 @@ public class Utils {
                 copy(in, out);
             }
 
-            if (etag.equals("-")) return true; //No-etag, don't store it
+            if (etag == null) return true; //No-etag, don't store it
 
             Files.write(etagFile, etag.getBytes());
 


### PR DESCRIPTION
Fixes #5 

Currently each etag is saved to the same file as where the file is being downloaded to but with `.etag` added on the end.

Also makes md5 hashes with only a single `-` be saved since the etags for the client and server jar files have those since they are multipart uploads in which case the etag is more complicated than simply being the md5 hash of the file.