### PR TITLE
Fix override between a class and an interface without a method in the common sub class not being detected

### DIFF
--- a/src/main/java/net/minecraftforge/lex/mappingtoy/JarMetadata.java
+++ b/src/main/java/net/minecraftforge/lex/mappingtoy/JarMetadata.java
@@ -395,7 +395,11 @@ public class JarMetadata {
                 children.add(info);
 
         for (MethodInfo myMtd : cls.methods.values()) {
+            if (myMtd.isStatic() || myMtd.isPrivate())
+                continue;
+
             Set<MethodInfo> overrides = new HashSet<>();
+            Set<MethodInfo> applyForcedName = new HashSet<>();
 
             for (ClassInfo child : children) {
                 Queue<ClassInfo> que = new LinkedList<>(Arrays.asList(child));
@@ -423,25 +427,35 @@ public class JarMetadata {
                                 continue;
                             if (!mtd.getName().equals(myMtd.getName()) || !mtd.getDesc().equals(myMtd.getDesc()))
                                 continue;
-                            overrides.add(mtd);
+                            if (!c.isInterface() || tree.instanceOf(c, cls)) {
+                                overrides.add(mtd);
+                            }
+                            applyForcedName.add(mtd);
                         }
                     }
                 }
             }
 
             if (!overrides.isEmpty()) {
-                for (MethodInfo override : overrides) {
+                for (MethodInfo m : overrides) {
+                    if (m.getOwner() != cls) {
+                        Set<Method> ovs = new TreeSet<>(m.getOverrides());
+                        ovs.add(myMtd.getMethod());
+                        m.setOverrides(ovs);
+                    }
+                }
+                
+                String forcedName = null;
+                for (MethodInfo override : applyForcedName) {
                     if (!override.getOwner().isLocal()) {
-                        overrides.forEach(m -> {
-                            if (m.getOwner() != cls) {
-                                Set<Method> ovs = new TreeSet<>(m.getOverrides());
-                                ovs.add(myMtd.getMethod());
-                                m.setOverrides(ovs);
-                            }
-                            m.forceName(override.getName());
-
-                        });
+                        forcedName = override.getName();
                         break;
+                    }
+                }
+                
+                for (MethodInfo m : applyForcedName) {
+                    if (forcedName != null) {
+                        m.forceName(forcedName);
                     }
                 }
             }


### PR DESCRIPTION
A few improvements to the `resolveTransitive` method:

- Checks that the method that is being overriden can be overriden
- Only adds an override when either the class with the overriding method is either not an interface or extends the class with the method that is being overriden (since interfaces currently cannot implement other interfaces methods) which fixes the case of it thinking that the `getString` method in `FormattedText` overrides the `getString` method in `Component` where `Component` extends `FormattedText` (does not change where the forced name is taken to or from)
- Allows for adding an override when there isn't a forced name to apply